### PR TITLE
Update Supervisely SDK to 6.73.564

### DIFF
--- a/hello_world/config.json
+++ b/hello_world/config.json
@@ -1,12 +1,13 @@
 {
     "name": "Hello World!",
     "type": "app",
+    "instance_version": "6.15.60",
     "version": "2.0.0",
     "categories": [
       "development"
     ],
     "description": "Demonstrates how to use Supervisely widgets",
-    "docker_image": "supervisely/base-py-sdk:latest",
+    "docker_image": "supervisely/base-py-sdk:6.73.564",
     "entrypoint": "python -m uvicorn 000_hello_world.src.main:app --host 0.0.0.0 --port 8000",
     "port": 8000,
     "icon": "https://user-images.githubusercontent.com/12828725/182186256-5ee663ad-25c7-4a62-9af1-fbfdca715b57.png",


### PR DESCRIPTION
Updates default Supervisely Docker apps to Supervisely SDK `6.73.564`.

- Updates `docker_image` tags for default Supervisely images.
- Updates Supervisely SDK references in requirements and Dockerfiles.
- Updates `instance_version` in app config files.
- Does not release applications.

Validation: generated ecosystem inventory report.
